### PR TITLE
fix: Update Tailwind CSS configuration to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",
+    "@tailwindcss/postcss": "^4.1.13",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
This commit resolves a build issue caused by an outdated Tailwind CSS PostCSS configuration. The version of `tailwindcss` used (v4 alpha) requires a separate PostCSS plugin.

The following changes were made:
- Added the `@tailwindcss/postcss` package to `devDependencies` in `package.json`.
- Updated `postcss.config.js` to use the new `@tailwindcss/postcss` plugin, as required by the latest version.

This should fix the build error and allow the project to be compiled successfully.