### PR TITLE
fix: Correct type-only imports to resolve rendering error

### DIFF
--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { ChevronRight, Star } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { boldFadeIn, staggerBold } from './animations';
 
 const AnnouncementsSection = ({ id }: SectionProps) => {

--- a/src/components/CompaniesSection.tsx
+++ b/src/components/CompaniesSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { boldFadeIn, staggerBold } from './animations';
 
 const CompaniesSection = ({ id }: SectionProps) => {

--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Calendar, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { boldFadeIn, staggerBold } from './animations';
 
 const EventsSection = ({ id }: SectionProps) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { Linkedin, Twitter, Facebook } from 'lucide-react';
 import { useNavItems } from '../hooks/useNavItems';
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { ChevronDown, Rocket, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 
 const HeroSection = ({ id }: SectionProps) => {
   const { t } = useTranslation();

--- a/src/components/PolicyInvestmentSection.tsx
+++ b/src/components/PolicyInvestmentSection.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FileText, TrendingUp, Rocket, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 
 const PolicyInvestmentSection = ({ id }: SectionProps) => {
   const { t } = useTranslation();

--- a/src/components/SupportOrgsSection.tsx
+++ b/src/components/SupportOrgsSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { boldFadeIn, staggerBold } from './animations';
 
 const SupportOrgsSection = ({ id }: SectionProps) => {

--- a/src/components/TechPatentsSection.tsx
+++ b/src/components/TechPatentsSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { SectionProps } from './types';
+import type { SectionProps } from './types';
 import { boldFadeIn, staggerBold } from './animations';
 
 const TechPatentsSection = ({ id }: SectionProps) => {


### PR DESCRIPTION
This commit fixes the critical 'blank page' rendering error. The issue was caused by the build tool incorrectly handling type-only imports for the `SectionProps` interface.

The fix was to change all instances of `import { SectionProps }` to `import type { SectionProps }`, which makes the import's type-only nature explicit to the TypeScript compiler and prevents a runtime error. The application should now render correctly.