### PR TITLE
fix: Correct unclosed JSX tag in TechPatentsSection

### DIFF
--- a/src/components/TechPatentsSection.tsx
+++ b/src/components/TechPatentsSection.tsx
@@ -44,7 +44,7 @@ const TechPatentsSection = ({ id }: SectionProps) => {
             ))}
           </motion.div>
         </div>
-      </div>
+      </motion.div>
     </section>
   );
 };


### PR DESCRIPTION
This commit fixes a critical JSX syntax error where a `<motion.div>` was not properly closed in the `TechPatentsSection` component. This error was breaking the application build and causing a blank page to render. The closing tag has been added, and the application should now render correctly.