### PR TITLE
feat: Increase animation duration by 5x

### DIFF
--- a/src/components/animations.ts
+++ b/src/components/animations.ts
@@ -1,19 +1,19 @@
 export const fadeInUp = {
   initial: { opacity: 0, y: 100 },
   animate: { opacity: 1, y: 0 },
-  transition: { duration: 0.8, ease: [0.6, 0.05, -0.01, 0.99] }
+  transition: { duration: 4.0, ease: [0.6, 0.05, -0.01, 0.99] }
 };
 
 export const slideInLeft = {
   initial: { opacity: 0, x: -100 },
   animate: { opacity: 1, x: 0 },
-  transition: { duration: 0.8, ease: [0.6, 0.05, -0.01, 0.99] }
+  transition: { duration: 4.0, ease: [0.6, 0.05, -0.01, 0.99] }
 };
 
 export const slideInRight = {
   initial: { opacity: 0, x: 100 },
   animate: { opacity: 1, x: 0 },
-  transition: { duration: 0.8, ease: [0.6, 0.05, -0.01, 0.99] }
+  transition: { duration: 4.0, ease: [0.6, 0.05, -0.01, 0.99] }
 };
 
 export const staggerParent = {


### PR DESCRIPTION
This commit updates the animation duration from 0.8s to 4.0s in `src/components/animations.ts` as requested by the user. This change applies globally to the `fadeInUp`, `slideInLeft`, and `slideInRight` variants, making the entrance animations for all sections significantly slower.