### PR TITLE
feat: Unify all section animations to 'fadeInUp'

### DIFF
--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { ChevronRight, Star } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { slideInLeft, staggerParent } from './animations';
+import { fadeInUp, staggerParent } from './animations';
 import { announcements } from '../data/announcements';
 
 const AnnouncementsSection = ({ id }: SectionProps) => {
@@ -35,7 +35,7 @@ const AnnouncementsSection = ({ id }: SectionProps) => {
           {announcements.map((announcement) => (
             <motion.div
               key={announcement.id}
-              variants={slideInLeft}
+              variants={fadeInUp}
               whileHover={{ scale: 1.02, y: -5 }}
               className={`rounded-2xl border-3 hover:shadow-2xl transition-all cursor-pointer overflow-hidden ${
                 announcement.priority

--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { Calendar, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { slideInRight, staggerParent } from './animations';
+import { fadeInUp, staggerParent } from './animations';
 import { events } from '../data/events';
 
 const EventsSection = ({ id }: SectionProps) => {
@@ -35,7 +35,7 @@ const EventsSection = ({ id }: SectionProps) => {
           {events.map((event) => (
             <motion.div
               key={event.id}
-              variants={slideInRight}
+              variants={fadeInUp}
               whileHover={{ scale: 1.05, y: -10 }}
               className={`bg-white rounded-2xl overflow-hidden shadow-xl hover:shadow-2xl transition-all cursor-pointer ${
                 event.featured ? 'ring-4 ring-[#FFC940] ring-opacity-50' : 'border-2 border-slate-200'

--- a/src/components/PolicyInvestmentSection.tsx
+++ b/src/components/PolicyInvestmentSection.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
 import { policies, investments } from '../data/policy';
-import { slideInRight } from './animations';
+import { fadeInUp } from './animations';
 
 const PolicyInvestmentSection = ({ id }: SectionProps) => {
   const { t } = useTranslation();
@@ -12,7 +12,7 @@ const PolicyInvestmentSection = ({ id }: SectionProps) => {
   return (
     <section id={id} className="py-24 bg-slate-50">
       <motion.div
-        variants={slideInRight}
+        variants={fadeInUp}
         initial="initial"
         whileInView="animate"
         viewport={{ once: true }}

--- a/src/components/SupportOrgsSection.tsx
+++ b/src/components/SupportOrgsSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { slideInLeft, staggerParent } from './animations';
+import { fadeInUp, staggerParent } from './animations';
 import { orgs } from '../data/supportOrgs';
 
 const SupportOrgsSection = ({ id }: SectionProps) => {
@@ -28,7 +28,7 @@ const SupportOrgsSection = ({ id }: SectionProps) => {
               {orgList.map(org => (
                 <motion.div
                   key={org.name}
-                  variants={slideInLeft}
+                  variants={fadeInUp}
                   whileHover={{ y: -5, scale: 1.05, boxShadow: "0px 10px 20px rgba(0,0,0,0.1)" }}
                   className="bg-slate-50 rounded-xl p-6 text-center transition-all"
                 >


### PR DESCRIPTION
This commit updates all section components to use a consistent `fadeInUp` animation, as requested by the user, for a more uniform look and feel. The `slideInLeft` and `slideInRight` variants have been removed from the components where they were used, and `fadeInUp` is now used globally for section entrances.