### PR TITLE
feat: Implement custom card animations

### DIFF
--- a/src/components/CompaniesSection.tsx
+++ b/src/components/CompaniesSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { fadeInUp, staggerParent } from './animations';
+import { cardList, cardItem } from './animations';
 import { companies } from '../data/companies';
 
 const CompaniesSection = ({ id }: SectionProps) => {
@@ -26,7 +26,7 @@ const CompaniesSection = ({ id }: SectionProps) => {
         </motion.div>
 
         <motion.div
-          variants={staggerParent}
+          variants={cardList}
           initial="initial"
           whileInView="animate"
           viewport={{ once: true }}
@@ -35,7 +35,7 @@ const CompaniesSection = ({ id }: SectionProps) => {
           {companies.map((company) => (
             <motion.div
               key={company.id}
-              variants={fadeInUp}
+              variants={cardItem}
               whileHover={{ scale: 1.05, y: -10 }}
               className="bg-white rounded-2xl border-3 border-slate-200 hover:border-[#0B2D63] hover:shadow-2xl transition-all cursor-pointer overflow-hidden"
             >

--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { Calendar, MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { fadeInUp, staggerParent } from './animations';
+import { cardList, cardItem } from './animations';
 import { events } from '../data/events';
 
 const EventsSection = ({ id }: SectionProps) => {
@@ -26,7 +26,7 @@ const EventsSection = ({ id }: SectionProps) => {
         </motion.div>
 
         <motion.div
-          variants={staggerParent}
+          variants={cardList}
           initial="initial"
           whileInView="animate"
           viewport={{ once: true }}
@@ -35,7 +35,7 @@ const EventsSection = ({ id }: SectionProps) => {
           {events.map((event) => (
             <motion.div
               key={event.id}
-              variants={fadeInUp}
+              variants={cardItem}
               whileHover={{ scale: 1.05, y: -10 }}
               className={`bg-white rounded-2xl overflow-hidden shadow-xl hover:shadow-2xl transition-all cursor-pointer ${
                 event.featured ? 'ring-4 ring-[#FFC940] ring-opacity-50' : 'border-2 border-slate-200'

--- a/src/components/PolicyInvestmentSection.tsx
+++ b/src/components/PolicyInvestmentSection.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
 import { policies, investments } from '../data/policy';
-import { fadeInUp } from './animations';
+import { cardList, cardItem } from './animations';
 
 const PolicyInvestmentSection = ({ id }: SectionProps) => {
   const { t } = useTranslation();
@@ -11,17 +11,11 @@ const PolicyInvestmentSection = ({ id }: SectionProps) => {
 
   return (
     <section id={id} className="py-24 bg-slate-50">
-      <motion.div
-        variants={fadeInUp}
-        initial="initial"
-        whileInView="animate"
-        viewport={{ once: true }}
-        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
-      >
-        <div className="text-center mb-16">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <motion.div initial={{ opacity: 0, y: 30 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} className="text-center mb-16">
           <h2 className="text-5xl font-black text-[#0B2D63] mb-6" dangerouslySetInnerHTML={{ __html: t('policy.title') }}></h2>
           <p className="text-xl text-slate-600 max-w-3xl mx-auto font-medium">{t('policy.subtitle')}</p>
-        </div>
+        </motion.div>
 
         <div className="flex justify-center mb-10">
           <div className="bg-slate-200 p-2 rounded-xl flex space-x-2">
@@ -34,37 +28,37 @@ const PolicyInvestmentSection = ({ id }: SectionProps) => {
           <AnimatePresence mode="wait">
             <motion.div
               key={activeTab}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.3 }}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              variants={cardList}
             >
               {activeTab === 'Policies' && (
                 <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
                   {policies.map(policy => (
-                    <div key={policy.title} className="bg-white p-6 rounded-xl shadow-lg hover:shadow-xl transition-all">
+                    <motion.div variants={cardItem} key={policy.title} className="bg-white p-6 rounded-xl shadow-lg hover:shadow-xl transition-all">
                       <policy.icon className="w-10 h-10 text-[#FFC940] mb-4" />
                       <h3 className="font-bold text-xl text-[#0B2D63] mb-2">{policy.title}</h3>
                       <p className="text-slate-600">{policy.description}</p>
-                    </div>
+                    </motion.div>
                   ))}
                 </div>
               )}
               {activeTab === 'Investments' && (
                 <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
                   {investments.map(inv => (
-                    <div key={inv.title} className="bg-white p-6 rounded-xl shadow-lg hover:shadow-xl transition-all text-center">
+                    <motion.div variants={cardItem} key={inv.title} className="bg-white p-6 rounded-xl shadow-lg hover:shadow-xl transition-all text-center">
                       <h3 className="font-black text-2xl text-[#0B2D63] mb-2">{inv.title}</h3>
                       <p className="text-4xl font-bold text-[#FFC940] mb-2">{inv.size}</p>
                       <p className="text-slate-500 font-semibold">Focus: {inv.focus}</p>
-                    </div>
+                    </motion.div>
                   ))}
                 </div>
               )}
             </motion.div>
           </AnimatePresence>
         </div>
-      </motion.div>
+      </div>
     </section>
   );
 };

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { motion, useInView, useMotionValue, useSpring } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { fadeInUp, staggerParent } from './animations';
+import { cardList, cardItem } from './animations';
 import { stats } from '../data/stats';
 
 const AnimatedNumber = ({ value }: { value: string }) => {
@@ -52,7 +52,7 @@ const StatsSection = () => {
         </motion.div>
 
         <motion.div
-          variants={staggerParent}
+          variants={cardList}
           initial="initial"
           whileInView="animate"
           viewport={{ once: true }}
@@ -61,7 +61,7 @@ const StatsSection = () => {
           {stats.map((stat) => (
             <motion.div
               key={stat.key}
-              variants={fadeInUp}
+              variants={cardItem}
               whileHover={{ scale: 1.05, y: -5 }}
               className={`text-center p-8 ${stat.bg} rounded-2xl shadow-xl hover:shadow-2xl transition-all border-2 border-white`}
             >

--- a/src/components/SupportOrgsSection.tsx
+++ b/src/components/SupportOrgsSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { SectionProps } from './types';
-import { fadeInUp, staggerParent } from './animations';
+import { cardList, cardItem } from './animations';
 import { orgs } from '../data/supportOrgs';
 
 const SupportOrgsSection = ({ id }: SectionProps) => {
@@ -24,11 +24,11 @@ const SupportOrgsSection = ({ id }: SectionProps) => {
         {Object.entries(groupedOrgs).map(([type, orgList]) => (
           <div key={type} className="mb-12">
             <h3 className="text-3xl font-bold text-slate-800 mb-8 border-l-4 border-[#FFC940] pl-4">{type}</h3>
-            <motion.div variants={staggerParent} initial="initial" whileInView="animate" viewport={{ once: true }} className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+            <motion.div variants={cardList} initial="initial" whileInView="animate" viewport={{ once: true }} className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
               {orgList.map(org => (
                 <motion.div
                   key={org.name}
-                  variants={fadeInUp}
+                  variants={cardItem}
                   whileHover={{ y: -5, scale: 1.05, boxShadow: "0px 10px 20px rgba(0,0,0,0.1)" }}
                   className="bg-slate-50 rounded-xl p-6 text-center transition-all"
                 >

--- a/src/components/animations.ts
+++ b/src/components/animations.ts
@@ -27,3 +27,33 @@ export const staggerParent = {
 export const buttonPress = {
   whileTap: { scale: 0.95 }
 };
+
+// Card section variants
+export const cardList = {
+  initial: {},
+  animate: {
+    transition: {
+      staggerChildren: 0.08,
+      delayChildren: 0.04
+    }
+  }
+};
+
+export const cardItem = {
+  initial: { opacity: 0, y: 24, scale: 0.98 },
+  animate: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: {
+      duration: 0.9,
+      ease: [0.25, 0.1, 0.25, 1],
+      opacity: { duration: 1.1, ease: "linear" }
+    }
+  },
+  exit: {
+    opacity: 0,
+    y: 12,
+    transition: { duration: 0.35, ease: [0.4, 0, 0.2, 1] }
+  }
+};


### PR DESCRIPTION
This commit implements the user's request for a more sophisticated card animation effect. New variants, `cardList` and `cardItem`, have been added to `animations.ts` and applied to all card-based sections. This creates a smoother, staggered 'float-in' effect for the cards.