### PR TITLE
fix: Replace unstable image URLs with placeholders

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -6,7 +6,7 @@ export const announcements = [
     date: "September 1, 2025",
     statusKey: "data.announcements.status.active",
     priority: true,
-    image: "https://images.unsplash.com/photo-1554224155-6726b3ff858f?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/funding/400/400",
     categoryKey: "data.announcements.category.funding"
   },
   {
@@ -16,7 +16,7 @@ export const announcements = [
     date: "August 28, 2025",
     statusKey: "data.announcements.status.open",
     priority: false,
-    image: "https://images.unsplash.com/photo-1517048676732-d65bc937f952?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/permits/400/400",
     categoryKey: "data.announcements.category.permits"
   },
   {
@@ -26,7 +26,7 @@ export const announcements = [
     date: "August 25, 2025",
     statusKey: "data.announcements.status.closing_soon",
     priority: true,
-    image: "https://images.unsplash.com/photo-1450101499163-c8848c66ca85?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/investment/400/400",
     categoryKey: "data.announcements.category.investment"
   },
   {
@@ -36,7 +36,7 @@ export const announcements = [
     date: "August 22, 2025",
     statusKey: "data.announcements.status.open",
     priority: false,
-    image: "https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/rd/400/400",
     categoryKey: "data.announcements.category.rd"
   },
   {
@@ -46,7 +46,7 @@ export const announcements = [
     date: "August 20, 2025",
     statusKey: "data.announcements.status.active",
     priority: true,
-    image: "https://images.unsplash.com/photo-1556761175-5973dc0f32e7?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/incubation/400/400",
     categoryKey: "data.announcements.category.incubation"
   },
   {
@@ -56,7 +56,7 @@ export const announcements = [
     date: "August 15, 2025",
     statusKey: "data.announcements.status.closed",
     priority: false,
-    image: "https://images.unsplash.com/photo-1581092580423-9c9780b6294a?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/grants/400/400",
     categoryKey: "data.announcements.category.grants"
   },
   {
@@ -66,7 +66,7 @@ export const announcements = [
     date: "August 10, 2025",
     statusKey: "data.announcements.status.active",
     priority: false,
-    image: "https://images.unsplash.com/photo-1542744095-291d1f67b221?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/partnership/400/400",
     categoryKey: "data.announcements.category.partnership"
   },
   {
@@ -76,7 +76,7 @@ export const announcements = [
     date: "August 5, 2025",
     statusKey: "data.announcements.status.open",
     priority: false,
-    image: "https://images.unsplash.com/photo-1615829239823-382d2b591248?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/commercialization/400/400",
     categoryKey: "data.announcements.category.commercialization"
   },
   {
@@ -86,7 +86,7 @@ export const announcements = [
     date: "July 30, 2025",
     statusKey: "data.announcements.status.completed",
     priority: true,
-    image: "https://images.unsplash.com/photo-1521791136064-7986c2920216?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80",
+    image: "https://picsum.photos/seed/recruitment/400/400",
     categoryKey: "data.announcements.category.recruitment"
   }
 ];

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1,92 +1,11 @@
 export const events = [
-  {
-    id: 1,
-    titleKey: "data.events.1.title",
-    locationKey: "data.events.1.location",
-    date: "October 15, 2025",
-    featured: true,
-    category: "SUMMIT",
-    image: "https://images.unsplash.com/photo-1511578314322-379afb476865?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "500+"
-  },
-  {
-    id: 2,
-    title: "CEO Forum: Digital Health Revolution",
-    date: "September 28, 2025",
-    location: "Bio Valley Complex",
-    featured: false,
-    category: "FORUM",
-    image: "https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "200+"
-  },
-  {
-    id: 3,
-    title: "International Investment Roundtable",
-    date: "September 20, 2025",
-    location: "Jeonju Chamber of Commerce",
-    featured: true,
-    category: "INVESTMENT",
-    image: "https://images.unsplash.com/photo-1552664730-d307ca884978?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "150+"
-  },
-  {
-    id: 4,
-    title: "Workshop: GMP Compliance for Startups",
-    date: "November 5, 2025",
-    location: "JB SQUARE Incubation Center",
-    featured: false,
-    category: "WORKSHOP",
-    image: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "50+"
-  },
-  {
-    id: 5,
-    title: "Agritech Demo Day 2025",
-    date: "November 12, 2025",
-    location: "Jeonbuk National University",
-    featured: false,
-    category: "DEMO DAY",
-    image: "https://images.unsplash.com/photo-1573496799652-408c2ac9fe98?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "300+"
-  },
-  {
-    id: 6,
-    title: "Networking Night: Bio-Pharma Professionals",
-    date: "November 20, 2025",
-    location: "The Grand Hill Hotel, Jeonju",
-    featured: true,
-    category: "NETWORKING",
-    image: "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "250+"
-  },
-  {
-    id: 7,
-    title: "Webinar: The Future of CRISPR Technology",
-    date: "December 2, 2025",
-    location: "Online",
-    featured: false,
-    category: "WEBINAR",
-    image: "https://images.unsplash.com/photo-1587825140708-df876c12b44e?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "1000+"
-  },
-  {
-    id: 8,
-    title: "JB Bio-Cluster Open House",
-    date: "December 10, 2025",
-    location: "JB SQUARE Main Campus",
-    featured: false,
-    category: "OPEN HOUSE",
-    image: "https://images.unsplash.com/photo-1582213782179-e0d53f98f2ca?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "400+"
-  },
-  {
-    id: 9,
-    title: "End-of-Year Gala & Awards Ceremony",
-    date: "December 18, 2025",
-    location: "Jeonju City Hall",
-    featured: true,
-    category: "GALA",
-    image: "https://images.unsplash.com/photo-1527529482837-4698179dc6ce?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80",
-    attendees: "350+"
-  }
+  { id: 1, titleKey: "data.events.1.title", locationKey: "data.events.1.location", date: "October 15, 2025", featured: true, category: "SUMMIT", image: "https://picsum.photos/seed/summit/800/600", attendees: "500+" },
+  { id: 2, titleKey: "data.events.2.title", locationKey: "data.events.2.location", date: "September 28, 2025", featured: false, category: "FORUM", image: "https://picsum.photos/seed/forum/800/600", attendees: "200+" },
+  { id: 3, titleKey: "data.events.3.title", locationKey: "data.events.3.location", date: "September 20, 2025", featured: true, category: "INVESTMENT", image: "https://picsum.photos/seed/investment_event/800/600", attendees: "150+" },
+  { id: 4, titleKey: "data.events.4.title", locationKey: "data.events.4.location", date: "November 5, 2025", featured: false, category: "WORKSHOP", image: "https://picsum.photos/seed/workshop/800/600", attendees: "50+" },
+  { id: 5, titleKey: "data.events.5.title", locationKey: "data.events.5.location", date: "November 12, 2025", featured: false, category: "DEMO DAY", image: "https://picsum.photos/seed/demoday/800/600", attendees: "300+" },
+  { id: 6, titleKey: "data.events.6.title", locationKey: "data.events.6.location", date: "November 20, 2025", featured: true, category: "NETWORKING", image: "https://picsum.photos/seed/networking/800/600", attendees: "250+" },
+  { id: 7, titleKey: "data.events.7.title", locationKey: "data.events.7.location", date: "December 2, 2025", featured: false, category: "WEBINAR", image: "https://picsum.photos/seed/webinar/800/600", attendees: "1000+" },
+  { id: 8, titleKey: "data.events.8.title", locationKey: "data.events.8.location", date: "December 10, 2025", featured: false, category: "OPEN HOUSE", image: "https://picsum.photos/seed/openhouse/800/600", attendees: "400+" },
+  { id: 9, titleKey: "data.events.9.title", locationKey: "data.events.9.location", date: "December 18, 2025", featured: true, category: "GALA", image: "https://picsum.photos/seed/gala/800/600", attendees: "350+" }
 ];


### PR DESCRIPTION
This commit fixes an issue where images were not loading in some sections. The unstable `images.unsplash.com` URLs have been replaced with reliable placeholders from `picsum.photos` in both `announcements.ts` and `events.ts` to ensure all images load correctly.