### PR TITLE
fix(i18n): Correct JSON syntax in locale file

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,7 +136,7 @@
       "4": { "attendees": "50+ Attendees" },
       "5": { "attendees": "300+ Attendees" },
       "6": { "attendees": "250+ Attendees" },
-      "7": "7": { "attendees": "1000+ Attendees" },
+      "7": { "attendees": "1000+ Attendees" },
       "8": { "attendees": "400+ Attendees" },
       "9": { "attendees": "350+ Attendees" }
     },


### PR DESCRIPTION
This commit fixes a build-breaking error caused by invalid JSON syntax in the `en.json` locale file.

A duplicate key was present in the `data.events` object, which caused the Vite JSON plugin to fail during the build process. This commit removes the duplicate key, ensuring the file is syntactically correct.

The `ko.json` file was also inspected and confirmed to be free of this error.