### PR TITLE
fix(styling): Improve visibility of HeroSection secondary button

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -36,7 +36,7 @@ const HeroSection = ({ id }: SectionProps) => {
               <span>{t('hero.exploreButton')}</span>
               <ChevronRight className="w-6 h-6" />
             </motion.button>
-            <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} className="w-full sm:w-auto px-12 py-5 border-3 border-white text-white font-black text-lg rounded-xl hover:bg-white hover:text-[#0B2D63] transition-all shadow-2xl">
+            <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} className="w-full sm:w-auto px-12 py-5 border-2 border-white/50 text-white font-black text-lg rounded-xl hover:bg-white hover:text-[#0B2D63] transition-all shadow-2xl bg-white/10 backdrop-blur-sm">
               {t('hero.companyDirectory')}
             </motion.button>
           </div>


### PR DESCRIPTION
This commit adjusts the styling of the 'Company Directory' button in the HeroSection to make it more prominent against the background image.

- Adds a semi-transparent white background (`bg-white/10`) and a backdrop blur (`backdrop-blur-sm`).
- Corrects an invalid Tailwind class from `border-3` to `border-2`.
- Adjusts border opacity to `border-white/50` to complement the new background.